### PR TITLE
Update parser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@microsoft/powerquery-parser": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.2.11.tgz",
-      "integrity": "sha512-8EYHM6GytFIkFyG4RzxbDU7PiWRv7SJ8A96nCNry6mgJOABY1FnsEWC9wrEGeBh8V4WnU1tY2kBwbt3ASxXKfg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@microsoft/powerquery-parser/-/powerquery-parser-0.2.12.tgz",
+      "integrity": "sha512-iqB5xjbSLlHwzTEyGTPN9ZUFlitmT8ZV4agt8YBGkPetHQy+BnAldHOHUx5sl0uLMrllk3fStupUaxyoypfnNw==",
       "requires": {
         "grapheme-splitter": "^1.0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerquery-formatter",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-formatter",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "typescript": "^3.9.5"
     },
     "dependencies": {
-        "@microsoft/powerquery-parser": "0.2.11"
+        "@microsoft/powerquery-parser": "0.2.12"
     },
     "files": [
         "lib/**/*"

--- a/src/error.ts
+++ b/src/error.ts
@@ -3,11 +3,11 @@
 
 import * as PQP from "@microsoft/powerquery-parser";
 
-export type TFormatError<S extends PQP.Parser.IParserState = PQP.Parser.IParserState> =
+export type TFormatError<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> =
     | PQP.Lexer.LexError.TLexError
     | PQP.Parser.ParseError.TParseError<S>;
 
-export function isTFormatError<S extends PQP.Parser.IParserState = PQP.Parser.IParserState>(
+export function isTFormatError<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     x: any,
 ): x is TFormatError<S> {
     return PQP.Lexer.LexError.isTLexError(x) || PQP.Parser.ParseError.isTParseError(x);

--- a/src/format.ts
+++ b/src/format.ts
@@ -14,23 +14,23 @@ import {
     trySerialize,
 } from "./serialize";
 
-export type TriedFormat<S extends PQP.Parser.IParserState = PQP.Parser.IParserState> = PQP.Result<
+export type TriedFormat<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> = PQP.Result<
     string,
     FormatError.TFormatError<S>
 >;
 
-export interface FormatSettings<S extends PQP.Parser.IParserState = PQP.Parser.IParserState> extends PQP.Settings<S> {
+export interface FormatSettings<S extends PQP.Parser.IParseState = PQP.Parser.IParseState> extends PQP.Settings<S> {
     readonly indentationLiteral: IndentationLiteral;
     readonly newlineLiteral: NewlineLiteral;
 }
 
-export const DefaultSettings: FormatSettings<PQP.Parser.IParserState> = {
+export const DefaultSettings: FormatSettings<PQP.Parser.IParseState> = {
     ...PQP.DefaultSettings,
     indentationLiteral: IndentationLiteral.SpaceX4,
     newlineLiteral: NewlineLiteral.Windows,
 };
 
-export function tryFormat<S extends PQP.Parser.IParserState = PQP.Parser.IParserState>(
+export function tryFormat<S extends PQP.Parser.IParseState = PQP.Parser.IParseState>(
     formatSettings: FormatSettings<S>,
     text: string,
 ): TriedFormat<S> {
@@ -43,14 +43,12 @@ export function tryFormat<S extends PQP.Parser.IParserState = PQP.Parser.IParser
     const root: PQP.Language.Ast.TNode = lexParseOk.root;
     const comments: ReadonlyArray<PQP.Language.Comment.TComment> = lexParseOk.lexerSnapshot.comments;
     const nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection = lexParseOk.state.contextState.nodeIdMapCollection;
-    const localizationTemplates: PQP.Templates.ILocalizationTemplates = PQP.LocalizationUtils.getLocalizationTemplates(
-        formatSettings.locale,
-    );
+    const locale: string = formatSettings.locale;
 
     let commentCollectionMap: CommentCollectionMap = new Map();
     if (comments.length) {
         const triedCommentPass: PQP.Traverse.TriedTraverse<CommentCollectionMap> = tryTraverseComment(
-            localizationTemplates,
+            locale,
             root,
             nodeIdMapCollection,
             comments,
@@ -63,7 +61,7 @@ export function tryFormat<S extends PQP.Parser.IParserState = PQP.Parser.IParser
     }
 
     const triedIsMultilineMap: PQP.Traverse.TriedTraverse<IsMultilineMap> = tryTraverseIsMultiline(
-        localizationTemplates,
+        locale,
         root,
         commentCollectionMap,
         nodeIdMapCollection,
@@ -74,7 +72,7 @@ export function tryFormat<S extends PQP.Parser.IParserState = PQP.Parser.IParser
     const isMultilineMap: IsMultilineMap = triedIsMultilineMap.value;
 
     const triedSerializeParameter: PQP.Traverse.TriedTraverse<SerializeParameterMap> = tryTraverseSerializeParameter(
-        localizationTemplates,
+        locale,
         root,
         nodeIdMapCollection,
         commentCollectionMap,
@@ -90,7 +88,7 @@ export function tryFormat<S extends PQP.Parser.IParserState = PQP.Parser.IParser
         serializeParameterMap,
     };
     const serializeRequest: SerializeSettings = {
-        locale: formatSettings.locale,
+        locale,
         root: lexParseOk.root,
         nodeIdMapCollection,
         passthroughMaps,

--- a/src/passes/comment.ts
+++ b/src/passes/comment.ts
@@ -7,13 +7,13 @@ import { CommentCollection, CommentCollectionMap, CommentState } from "./commonT
 // TODO pass in leafNodeIds instead for a big speed boost.
 // Returns a Map<a leaf node's id number, an array of comments attached to the node id>.
 export function tryTraverseComment(
-    localizationTemplates: PQP.Templates.ILocalizationTemplates,
+    locale: string,
     root: PQP.Language.Ast.TNode,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     comments: ReadonlyArray<PQP.Language.Comment.TComment>,
 ): PQP.Traverse.TriedTraverse<CommentCollectionMap> {
     const state: CommentState = {
-        localizationTemplates,
+        locale,
         result: new Map(),
         comments,
         commentsIndex: 0,

--- a/src/passes/commonTypes.ts
+++ b/src/passes/commonTypes.ts
@@ -22,7 +22,6 @@ export interface CommentState extends PQP.Traverse.IState<CommentCollectionMap> 
 }
 
 export interface IsMultilineFirstPassState extends PQP.Traverse.IState<IsMultilineMap> {
-    readonly localizationTemplates: PQP.Templates.ILocalizationTemplates;
     readonly commentCollectionMap: CommentCollectionMap;
     readonly nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection;
     readonly linearLengthMap: LinearLengthMap;
@@ -62,7 +61,6 @@ export interface SerializeParameterMap {
 }
 
 export interface SerializeParameterState extends PQP.Traverse.IState<SerializeParameterMap> {
-    readonly localizationTemplates: PQP.Templates.ILocalizationTemplates;
     readonly nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection;
     readonly commentCollectionMap: CommentCollectionMap;
     readonly isMultilineMap: IsMultilineMap;

--- a/src/passes/isMultiline/isMultiline.ts
+++ b/src/passes/isMultiline/isMultiline.ts
@@ -8,13 +8,13 @@ import { tryTraverseIsMultilineSecondPass } from "./isMultilineSecondPass";
 
 // runs a DFS pass followed by a BFS pass.
 export function tryTraverseIsMultiline(
-    localizationTemplates: PQP.Templates.ILocalizationTemplates,
+    locale: string,
     ast: PQP.Language.Ast.TNode,
     commentCollectionMap: CommentCollectionMap,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
 ): PQP.Traverse.TriedTraverse<IsMultilineMap> {
     const triedFirstPass: PQP.Traverse.TriedTraverse<IsMultilineMap> = tryTraverseIsMultilineFirstPass(
-        localizationTemplates,
+        locale,
         ast,
         commentCollectionMap,
         nodeIdMapCollection,
@@ -24,5 +24,5 @@ export function tryTraverseIsMultiline(
     }
     const isMultilineMap: IsMultilineMap = triedFirstPass.value;
 
-    return tryTraverseIsMultilineSecondPass(localizationTemplates, ast, isMultilineMap, nodeIdMapCollection);
+    return tryTraverseIsMultilineSecondPass(locale, ast, isMultilineMap, nodeIdMapCollection);
 }

--- a/src/passes/isMultiline/isMultilineFirstPass.ts
+++ b/src/passes/isMultiline/isMultilineFirstPass.ts
@@ -13,13 +13,13 @@ import { expectGetIsMultiline, setIsMultiline } from "./common";
 import { getLinearLength } from "./linearLength";
 
 export function tryTraverseIsMultilineFirstPass(
-    localizationTemplates: PQP.Templates.ILocalizationTemplates,
+    locale: string,
     ast: PQP.Language.Ast.TNode,
     commentCollectionMap: CommentCollectionMap,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
 ): PQP.Traverse.TriedTraverse<IsMultilineMap> {
     const state: IsMultilineFirstPassState = {
-        localizationTemplates,
+        locale,
         result: new Map(),
         commentCollectionMap,
         nodeIdMapCollection,
@@ -82,7 +82,7 @@ function visitNode(state: IsMultilineFirstPassState, node: PQP.Language.Ast.TNod
                 isMultiline = true;
             }
             const linearLength: number = getLinearLength(
-                state.localizationTemplates,
+                state.locale,
                 state.nodeIdMapCollection,
                 state.linearLengthMap,
                 node,
@@ -214,12 +214,7 @@ function visitNode(state: IsMultilineFirstPassState, node: PQP.Language.Ast.TNod
 
             if (args.length > 1) {
                 const linearLengthMap: LinearLengthMap = state.linearLengthMap;
-                const linearLength: number = getLinearLength(
-                    state.localizationTemplates,
-                    nodeIdMapCollection,
-                    linearLengthMap,
-                    node,
-                );
+                const linearLength: number = getLinearLength(state.locale, nodeIdMapCollection, linearLengthMap, node);
 
                 const maybeArrayWrapper: PQP.Language.Ast.TNode | undefined = PQP.Parser.NodeIdMapUtils.maybeParentAst(
                     nodeIdMapCollection,
@@ -247,7 +242,7 @@ function visitNode(state: IsMultilineFirstPassState, node: PQP.Language.Ast.TNod
                 const recursivePrimaryExpression: PQP.Language.Ast.RecursivePrimaryExpression = maybeRecursivePrimaryExpression;
 
                 const headLinearLength: number = getLinearLength(
-                    state.localizationTemplates,
+                    state.locale,
                     nodeIdMapCollection,
                     linearLengthMap,
                     recursivePrimaryExpression.head,

--- a/src/passes/isMultiline/isMultilineSecondPass.ts
+++ b/src/passes/isMultiline/isMultilineSecondPass.ts
@@ -6,13 +6,13 @@ import { IsMultilineMap, IsMultilineSecondPassState } from "../commonTypes";
 import { expectGetIsMultiline, setIsMultiline } from "./common";
 
 export function tryTraverseIsMultilineSecondPass(
-    localizationTemplates: PQP.Templates.ILocalizationTemplates,
+    locale: string,
     ast: PQP.Language.Ast.TNode,
     isMultilineMap: IsMultilineMap,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
 ): PQP.Traverse.TriedTraverse<IsMultilineMap> {
     const state: IsMultilineSecondPassState = {
-        localizationTemplates,
+        locale,
         result: isMultilineMap,
         nodeIdMapCollection,
     };

--- a/src/passes/isMultiline/linearLength.ts
+++ b/src/passes/isMultiline/linearLength.ts
@@ -11,7 +11,7 @@ import { LinearLengthMap, LinearLengthState } from "../commonTypes";
 //
 // Some nodes are always multiline, such as IfExpression, and will return NaN.
 export function getLinearLength(
-    localizationTemplates: PQP.Templates.ILocalizationTemplates,
+    locale: string,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     linearLengthMap: LinearLengthMap,
     node: PQP.Language.Ast.TNode,
@@ -20,12 +20,7 @@ export function getLinearLength(
     const maybeLinearLength: number | undefined = linearLengthMap.get(nodeId);
 
     if (maybeLinearLength === undefined) {
-        const linearLength: number = calculateLinearLength(
-            localizationTemplates,
-            node,
-            nodeIdMapCollection,
-            linearLengthMap,
-        );
+        const linearLength: number = calculateLinearLength(locale, node, nodeIdMapCollection, linearLengthMap);
         linearLengthMap.set(nodeId, linearLength);
         return linearLength;
     } else {
@@ -34,13 +29,13 @@ export function getLinearLength(
 }
 
 function calculateLinearLength(
-    localizationTemplates: PQP.Templates.ILocalizationTemplates,
+    locale: string,
     node: PQP.Language.Ast.TNode,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     linearLengthMap: LinearLengthMap,
 ): number {
     const state: LinearLengthState = {
-        localizationTemplates,
+        locale,
         result: 0,
         nodeIdMapCollection,
         linearLengthMap,
@@ -389,7 +384,7 @@ function sumLinearLengths(
     for (const maybeNode of maybeNodes) {
         if (maybeNode) {
             const nodeLinearLength: number = getLinearLength(
-                state.localizationTemplates,
+                state.locale,
                 state.nodeIdMapCollection,
                 state.linearLengthMap,
                 maybeNode,

--- a/src/passes/serializeParameter.ts
+++ b/src/passes/serializeParameter.ts
@@ -12,7 +12,7 @@ import { visitNode } from "./visitNode/visitNode";
 //   done by calling setWorkspace(state, childNode, workspace)
 
 export function tryTraverseSerializeParameter(
-    localizationTemplates: PQP.Templates.ILocalizationTemplates,
+    locale: string,
     ast: PQP.Language.Ast.TNode,
     nodeIdMapCollection: PQP.Parser.NodeIdMap.Collection,
     commentCollectionMap: CommentCollectionMap,
@@ -24,7 +24,7 @@ export function tryTraverseSerializeParameter(
             indentationChange: new Map(),
             comments: new Map(),
         },
-        localizationTemplates,
+        locale,
         nodeIdMapCollection,
         commentCollectionMap,
         isMultilineMap,

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -36,9 +36,7 @@ export interface SerializePassthroughMaps {
 }
 
 export function trySerialize(settings: SerializeSettings): TriedSerialize {
-    return PQP.ResultUtils.ensureResult(PQP.LocalizationUtils.getLocalizationTemplates(settings.locale), () =>
-        serialize(settings),
-    );
+    return PQP.ResultUtils.ensureResult(settings.locale, () => serialize(settings));
 }
 
 interface SerializeState {


### PR DESCRIPTION
The two "big" changes from the formatter's perspective was the `IParserState -> IParseState` rename, and how any public API which had `PQP.Templates.ILocalizationTemplates` as a type was changed to a string named "locale".