### PR TITLE
fix. support comments prefixed to the EOF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/powerquery-formatter",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/powerquery-formatter",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/powerquery-parser": "0.9.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/powerquery-formatter",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {

--- a/src/powerquery-formatter/format.ts
+++ b/src/powerquery-formatter/format.ts
@@ -6,7 +6,9 @@ import { Trace, TraceManager } from "@microsoft/powerquery-parser/lib/powerquery
 import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import {
+    CommentCollection,
     CommentCollectionMap,
+    CommentResult,
     IsMultilineMap,
     SerializeParameterMap,
     tryTraverseComment,
@@ -71,8 +73,13 @@ export async function tryFormat(formatSettings: FormatSettings, text: string): P
 
     let commentCollectionMap: CommentCollectionMap = new Map();
 
+    let eofCommentCollection: CommentCollection = {
+        prefixedComments: [],
+        prefixedCommentsContainsNewline: false,
+    };
+
     if (comments.length) {
-        const triedCommentPass: PQP.Traverse.TriedTraverse<CommentCollectionMap> = await tryTraverseComment(
+        const triedCommentPass: PQP.Traverse.TriedTraverse<CommentResult> = await tryTraverseComment(
             ast,
             nodeIdMapCollection,
             comments,
@@ -86,7 +93,8 @@ export async function tryFormat(formatSettings: FormatSettings, text: string): P
             return triedCommentPass;
         }
 
-        commentCollectionMap = triedCommentPass.value;
+        commentCollectionMap = triedCommentPass.value.commentCollectionMap;
+        eofCommentCollection = triedCommentPass.value.eofCommentCollection;
     }
 
     const triedIsMultilineMap: PQP.Traverse.TriedTraverse<IsMultilineMap> = await tryTraverseIsMultiline(
@@ -125,6 +133,7 @@ export async function tryFormat(formatSettings: FormatSettings, text: string): P
 
     const passthroughMaps: SerializePassthroughMaps = {
         commentCollectionMap,
+        eofCommentCollection,
         serializeParameterMap,
     };
 

--- a/src/powerquery-formatter/formatV2.ts
+++ b/src/powerquery-formatter/formatV2.ts
@@ -6,6 +6,7 @@ import { Trace, TraceManager } from "@microsoft/powerquery-parser/lib/powerquery
 import { Ast } from "@microsoft/powerquery-parser/lib/powerquery-parser/language";
 
 import {
+    CommentCollection,
     CommentCollectionMap,
     CommentResultV2,
     SerializeParameterMapV2,
@@ -46,6 +47,12 @@ export async function tryFormatV2(formatSettings: FormatSettings, text: string):
     const maybeCancellationToken: PQP.ICancellationToken | undefined = formatSettings.maybeCancellationToken;
 
     let commentCollectionMap: CommentCollectionMap = new Map();
+
+    let eofCommentCollection: CommentCollection = {
+        prefixedComments: [],
+        prefixedCommentsContainsNewline: false,
+    };
+
     const containerIdHavingComments: Set<number> = new Set();
 
     if (comments.length) {
@@ -64,6 +71,7 @@ export async function tryFormatV2(formatSettings: FormatSettings, text: string):
         }
 
         commentCollectionMap = triedCommentPass.value.commentCollectionMap;
+        eofCommentCollection = triedCommentPass.value.eofCommentCollection;
 
         const containerIdHavingCommentsChildCount: Map<number, number> =
             triedCommentPass.value.containerIdHavingCommentsChildCount;
@@ -129,6 +137,7 @@ export async function tryFormatV2(formatSettings: FormatSettings, text: string):
 
     const passthroughMaps: SerializePassthroughMapsV2 = {
         commentCollectionMap,
+        eofCommentCollection,
         containerIdHavingComments,
         serializeParameterMap,
     };

--- a/src/powerquery-formatter/passes/commonTypes.ts
+++ b/src/powerquery-formatter/passes/commonTypes.ts
@@ -15,7 +15,12 @@ export interface CommentCollection {
     prefixedCommentsContainsNewline: boolean;
 }
 
-export interface CommentState extends PQP.Traverse.ITraversalState<CommentCollectionMap> {
+export interface CommentResult {
+    readonly commentCollectionMap: CommentCollectionMap;
+    readonly eofCommentCollection: CommentCollection;
+}
+
+export interface CommentState extends PQP.Traverse.ITraversalState<CommentResult> {
     readonly comments: ReadonlyArray<PQP.Language.Comment.TComment>;
     commentsIndex: number;
     maybeCurrentComment: PQP.Language.Comment.TComment | undefined;
@@ -71,6 +76,7 @@ export interface CommentResultV2 {
     readonly commentCollectionMap: CommentCollectionMap;
     readonly containerIdHavingCommentsChildCount: Map<number, number>;
     readonly parentContainerIdOfNodeId: Map<number, number>;
+    readonly eofCommentCollection: CommentCollection;
 }
 
 export interface CommentStateV2 extends PQP.Traverse.ITraversalState<CommentResultV2> {

--- a/src/powerquery-formatter/serializeV2.ts
+++ b/src/powerquery-formatter/serializeV2.ts
@@ -29,6 +29,7 @@ export interface SerializeSettingsV2 extends PQP.CommonSettings {
 
 export interface SerializePassthroughMapsV2 {
     readonly commentCollectionMap: CommentCollectionMap;
+    readonly eofCommentCollection: CommentCollection;
     readonly containerIdHavingComments: Set<number>;
     readonly serializeParameterMap: SerializeParameterMapV2;
 }
@@ -103,6 +104,7 @@ async function serializeV2(settings: SerializeSettingsV2): Promise<string> {
 
     // eslint-disable-next-line @typescript-eslint/await-thenable
     await serializeNode(state, state.node, { isParentInline: isRootInline });
+    visitComments(state, settings.passthroughMaps.eofCommentCollection);
 
     // force cleaning whitespaces and appending crlf to the eof
     state.formatted = cleanUpTailingCrLfOfString(state.formatted);

--- a/src/test/comments.ts
+++ b/src/test/comments.ts
@@ -125,5 +125,29 @@ y = 1;`.trim();
             const actual: string = await expectFormat("section foobar; x = 1; // lineComment\n y = 1;");
             compare(expected, actual);
         });
+
+        it("let y = 1 in y // stuff", async () => {
+            const expected: string = `
+let
+    y = 1
+in
+    y
+// stuff`.trim();
+
+            const actual: string = await expectFormat("let y = 1 in y // stuff");
+            compare(expected, actual);
+        });
+
+        it("let y = 1 in y /* foo */", async () => {
+            const expected: string = `
+let
+    y = 1
+in
+    y
+/* foo */`.trim();
+
+            const actual: string = await expectFormat("let y = 1 in y /* foo */");
+            compare(expected, actual);
+        });
     });
 });

--- a/src/test/commentsV2.ts
+++ b/src/test/commentsV2.ts
@@ -222,5 +222,48 @@ y = 1;
             compareV2(expected, actual);
             compareV2(expected2, actual2);
         });
+
+        it("let y = 1 in y // stuff", async () => {
+            const expected: string = `
+let
+    y = 1
+in
+    y
+// stuff
+`;
+
+            const expected2: string = `
+let y = 1 in y
+// stuff
+`;
+
+            const actual: string = await expectFormatV2("let y = 1 in y // stuff");
+
+            const actual2: string = await expectFormatV2("let y = 1 in y // stuff", DefaultFormatSettings2);
+
+            compareV2(expected, actual);
+            compareV2(expected2, actual2);
+        });
+
+        it("let y = 1 in y /* foo */ ", async () => {
+            const expected: string = `
+let
+    y = 1
+in
+    y
+/* foo */
+`;
+
+            const expected2: string = `
+let y = 1 in y/* foo */
+`;
+
+            const actual: string = await expectFormatV2("let y = 1 in y /* foo */ ");
+
+            const actual2: string = await expectFormatV2("let y = 1 in y /* foo */", DefaultFormatSettings2);
+
+            compareV2(expected, actual);
+            compareV2(expected2, actual2);
+        });
     });
 });


### PR DESCRIPTION
support all those comments prefixed to the EOF

and it should have https://github.com/microsoft/vscode-powerquery/issues/144 resolved 